### PR TITLE
Type4Py supports prediction for the type of variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ This repository contains the implementation of Type4Py and instructions for re-p
 - [Citing Type4Py](#citing-type4py)
 
 # Dataset
-Type4Py dataset can be downloaded from [here](https://surfdrive.surf.nl/files/index.php/s/KobWgHFgXUgW4rA). It contains around 4,910 Python projects from GitHub, which were cloned in October 2019.
-
-## Code de-duplication
-Same as the paper, it is essential to de-duplicate the dataset for avoiding duplication bias when training and testing the model. Check out the `CD4Py` [tool](https://github.com/saltudelft/CD4Py) for code de-duplication.
+For Type4Py, we use the **ManyTypes4Py** dataset. You can download the latest version of the dataset [here](https://zenodo.org/record/4719447).
+Also, note that the dataset is already de-duplicated.
 
 # Installation Guide
 ## Requirements
@@ -27,6 +25,7 @@ pip install .
 # Usage Guide
 Follow the below steps to train and evaluate the Type4Py model.
 ## 1. Extraction
+**NOTE:** Skip this step if you're using the ManyTypes4Py dataset.
 ```
 $ type4py extract --c $DATA_PATH --o $OUTPUT_DIR --d $DUP_FILES --w $CORES
 ```
@@ -41,7 +40,7 @@ Description:
 $ type4py preprocess --o $OUTPUT_DIR --l $LIMIT
 ```
 Description:
-- `$OUTPUT_DIR`: The path that was used in the first step to store processed projects.
+- `$OUTPUT_DIR`: The path that was used in the first step to store processed projects. For the MT4Py dataset, use the directory in which the dataset is extracted.
 - `$LIMIT`: The number of projects to be processed. [Optional]
 
 ## 3. Vectorizing
@@ -49,15 +48,16 @@ Description:
 $ type4py vectorize --o $OUTPUT_DIR
 ```
 Description:
-- `$OUTPUT_DIR`: The path that was used in the first step to store processed projects.
+- `$OUTPUT_DIR`: The path that was used in the previous step to store processed projects.
 
 ## 4. Learning
 ```
 $ type4py learn --o $OUTPUT_DIR --c --p $PARAM_FILE
 ```
 Description:
-- `$OUTPUT_DIR`: The path that was used in the first step to store processed projects.
-- `--c`: Trains the model for the combined prediction task. Use `--a` and `--r` for argument and return type prediction tasks, respectively.
+- `$OUTPUT_DIR`: The path that was used in the previous step to store processed projects.
+- `--c`: Trains the complete model. Use `type4py learn -h` to see other configurations.
+
 - `--p $PARAM_FILE`: The path to user-provided hyper-parameters for the model. See [this](https://github.com/saltudelft/type4py/blob/main/type4py/model_params.json) file as an example. [Optional]
 
 ## 5. Testing
@@ -67,7 +67,7 @@ $ type4py predict --o $OUTPUT_DIR --c
 
 Description:
 - `$OUTPUT_DIR`: The path that was used in the first step to store processed projects.
-- `--c`: Tests the model for the combined prediction task. Use `--a` and `--r` for argument and return type prediction tasks, respectively. Note that this argument should be the same as the one that was used in the learning step.
+- `--c`: Predicts using the complete model. Use `type4py predict -h` to see other configurations.
 
 ## 6. Evaluating
 ```
@@ -76,7 +76,7 @@ $ type4py eval --o $OUTPUT_DIR --c --tp 10
 
 Description:
 - `$OUTPUT_DIR`: The path that was used in the first step to store processed projects.
-- `--c`: Evaluates the model for the combined prediction task. Use `--a` and `--r` for argument and return type prediction tasks, respectively. Note that this argument should be the same as the one that was used in the learning step.
+- `--c`: Evaluates the complete model. Use `type4py eval -h` to see other configurations.
 - `--tp 10`: Considers Top-10 predictions for evaluation. For this argument, You can choose a positive integer between 1 and 10. [Optional]
 
 # Citing Type4Py

--- a/type4py/__init__.py
+++ b/type4py/__init__.py
@@ -13,5 +13,7 @@ __version__ = "0.1"
 # Constants and parameters
 MIN_DATA_POINTS = 3
 AVAILABLE_TYPES_NUMBER = 1024
+KNN_TREE_SIZE = 20
+MAX_PARAM_TYPE_DEPTH = 2
 
 

--- a/type4py/__init__.py
+++ b/type4py/__init__.py
@@ -9,3 +9,9 @@ logger_sh.setFormatter(logging.Formatter(fmt='[%(asctime)s][%(name)s][%(levelnam
 logger.addHandler(logger_sh)
 
 __version__ = "0.1"
+
+# Constants and parameters
+MIN_DATA_POINTS = 3
+AVAILABLE_TYPES_NUMBER = 1024
+
+

--- a/type4py/__main__.py
+++ b/type4py/__main__.py
@@ -16,6 +16,10 @@ data_loading_ret = {'train': data_loaders.load_ret_train_data, 'valid': data_loa
                      'test': data_loaders.load_ret_test_data, 'labels': data_loaders.load_ret_labels, 
                      'name': 'return'}
 
+data_loading_var = {'train': data_loaders.load_var_train_data, 'valid': data_loaders.load_var_valid_data,
+                     'test': data_loaders.load_var_test_data, 'labels': data_loaders.load_var_labels, 
+                     'name': 'variable'}
+
 def extract(args):
     p = Pipeline(args.c, args.o, True, False, args.d)
     p.run(find_repos_list(args.c), args.w)
@@ -37,6 +41,8 @@ def learn(args):
         train(args.o, data_loading_param, args.p)
     elif args.r:
         train(args.o, data_loading_ret, args.p)
+    elif args.v:
+        train(args.o, data_loading_var, args.p)
     else:
         train(args.o, data_loading_comb, args.p)
 
@@ -47,6 +53,8 @@ def predict(args):
         test(args.o, data_loading_param)
     elif args.r:
         test(args.o, data_loading_ret)
+    elif args.v:
+        test(args.o, data_loading_var)
     else:
         test(args.o, data_loading_comb)
 
@@ -57,6 +65,8 @@ def eval(args):
         evaluate(args.o, data_loading_param, args.tp)
     elif args.r:
         evaluate(args.o, data_loading_ret, args.tp)
+    elif args.v:
+        evaluate(args.o, data_loading_var, args.tp)
     else:
         evaluate(args.o, data_loading_comb, args.tp)
 
@@ -90,6 +100,7 @@ def main():
     learning_parser.add_argument('--c', '--combined', default=True, action="store_true", help="combined prediction task")
     learning_parser.add_argument('--a', '--argument', default=False, action="store_true", help="argument prediction task")
     learning_parser.add_argument('--r', '--return', default=False, action="store_true", help="return prediction task")
+    learning_parser.add_argument('--v', '--variable', default=False, action="store_true", help="variable prediction task")
     learning_parser.add_argument('--p', '--parameters', required=False, type=str, help="Path to the JSON file of model's hyper-parameters")
     learning_parser.set_defaults(func=learn)
 
@@ -99,6 +110,7 @@ def main():
     predict_parser.add_argument('--c', '--combined', default=True, action="store_true", help="combined prediction task")
     predict_parser.add_argument('--a', '--argument', default=False, action="store_true", help="argument prediction task")
     predict_parser.add_argument('--r', '--return', default=False, action="store_true", help="return prediction task")
+    predict_parser.add_argument('--v', '--variable', default=False, action="store_true", help="variable prediction task")
     predict_parser.set_defaults(func=predict)
 
     # Evaluation phase
@@ -107,6 +119,7 @@ def main():
     eval_parser.add_argument('--c', '--combined', default=True, action="store_true", help="combined prediction task")
     eval_parser.add_argument('--a', '--argument', default=False, action="store_true", help="argument prediction task")
     eval_parser.add_argument('--r', '--return', default=False, action="store_true", help="return prediction task")
+    eval_parser.add_argument('--v', '--variable', default=False, action="store_true", help="variable prediction task")
     eval_parser.add_argument('--tp', '--topn', default=10, type=int, help="Report top-n predictions [default n=10]")
     eval_parser.set_defaults(func=eval)
 

--- a/type4py/__main__.py
+++ b/type4py/__main__.py
@@ -62,13 +62,13 @@ def eval(args):
     from type4py.eval import evaluate
     setup_logs_file(args.o, "eval")
     if args.a:
-        evaluate(args.o, data_loading_param, args.tp)
+        evaluate(args.o, data_loading_param, {'Parameter'}, args.tp)
     elif args.r:
-        evaluate(args.o, data_loading_ret, args.tp)
+        evaluate(args.o, data_loading_ret, {'Return'}, args.tp)
     elif args.v:
-        evaluate(args.o, data_loading_var, args.tp)
+        evaluate(args.o, data_loading_var, {'Variable'}, args.tp)
     else:
-        evaluate(args.o, data_loading_comb, args.tp)
+        evaluate(args.o, data_loading_comb, {'Parameter', 'Return', 'Variable'}, args.tp)
 
 def main():
     arg_parser = argparse.ArgumentParser()

--- a/type4py/__main__.py
+++ b/type4py/__main__.py
@@ -53,13 +53,13 @@ def learn(args):
     from type4py.learn import train
     setup_logs_file(args.o, "learn")
     if args.woi:
-        train(args.o, data_loading_woi, args.p)
+        train(args.o, data_loading_woi, args.p, args.v)
     elif args.woc:
-        train(args.o, data_loading_woc, args.p)
+        train(args.o, data_loading_woc, args.p, args.v)
     elif args.wov:
-        train(args.o, data_loading_wov, args.p)
+        train(args.o, data_loading_wov, args.p, args.v)
     else:
-        train(args.o, data_loading_comb, args.p)
+        train(args.o, data_loading_comb, args.p, args.v)
 
 def predict(args):
     from type4py.predict import test
@@ -70,7 +70,7 @@ def predict(args):
         test(args.o, data_loading_woc)
     elif args.wov:
         test(args.o, data_loading_wov)
-    else:
+    elif args.c:
         test(args.o, data_loading_comb)
 
 def eval(args):
@@ -114,17 +114,18 @@ def main():
     # Learning phase
     learning_parser = sub_parsers.add_parser('learn')
     learning_parser.add_argument('--o', '--output', required=True, type=str, help="Path to processed projects")
-    #learning_parser.add_argument('--c', '--combined', default=True, action="store_true", help="combined prediction task")
+    learning_parser.add_argument('--c', '--complete', default=True, action="store_true", help="Complete Type4Py model")
     learning_parser.add_argument('--woi', default=False, action="store_true", help="Type4py model w/o identifiers")
     learning_parser.add_argument('--woc', default=False, action="store_true", help="Type4py model w/o code contexts")
     learning_parser.add_argument('--wov', default=False, action="store_true", help="Type4py model w/o visible type hints")
     learning_parser.add_argument('--p', '--parameters', required=False, type=str, help="Path to the JSON file of model's hyper-parameters")
+    learning_parser.add_argument('--v', '--validation', default=False, action="store_true", help="Evaluating Type4Py on the validation set when training")
     learning_parser.set_defaults(func=learn)
 
     # Prediction phase
     predict_parser = sub_parsers.add_parser('predict')
     predict_parser.add_argument('--o', '--output', required=True, type=str, help="Path to processed projects")
-    #predict_parser.add_argument('--c', '--combined', default=True, action="store_true", help="combined prediction task")
+    predict_parser.add_argument('--c', '--complete', default=True, action="store_true", help="Complete Type4Py model")
     predict_parser.add_argument('--woi', default=False, action="store_true", help="Type4py model w/o identifiers")
     predict_parser.add_argument('--woc', default=False, action="store_true", help="Type4py model w/o code contexts")
     predict_parser.add_argument('--wov', default=False, action="store_true", help="Type4py model w/o visible type hints")

--- a/type4py/data_loaders.py
+++ b/type4py/data_loaders.py
@@ -1,10 +1,13 @@
+from type4py import logger, MIN_DATA_POINTS
 from typing import Tuple
 from os.path import join
 from collections import Counter
-from torch.utils.data import TensorDataset
+from time import time
+from torch.utils.data import TensorDataset, DataLoader
 import torch
 import numpy as np
 
+logger.name = __name__
 
 def load_data_tensors_TW(filename, limit=-1):
     return torch.from_numpy(np.load(filename)).float()
@@ -37,16 +40,20 @@ def load_combined_valid_data(output_path: str):
                       load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'var_valid_aval_types_dp.npy'))))
 
 def load_combined_test_data(output_path: str):
-    return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_param_test_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_ret_test_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_var_test_datapoints_x.npy')))), \
+    id_p_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_param_test_datapoints_x.npy'))
+    id_r_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_ret_test_datapoints_x.npy'))
+    id_v_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_var_test_datapoints_x.npy'))
+
+    return torch.cat((id_p_te, id_r_te, id_v_te)), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_param_test_datapoints_x.npy')),
                       load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_ret_test_datapoints_x.npy')),
                       load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_var_test_datapoints_x.npy')))), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'params_test_aval_types_dp.npy')),
                       load_data_tensors_TW(join(output_path, 'vectors', 'test', 'ret_test_aval_types_dp.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'var_test_aval_types_dp.npy'))))
-
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'var_test_aval_types_dp.npy')))), \
+           (len(id_p_te)-1, (len(id_p_te)+len(id_r_te))-1, (len(id_p_te)+len(id_r_te)+len(id_v_te))-1)
+           # indexes of combined test data for separating between prediction tasks
+           
 def load_combined_labels(output_path: str):
     return torch.cat((load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'params_train_dps_y_all.npy')),
                       load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'ret_train_dps_y_all.npy')),
@@ -57,6 +64,94 @@ def load_combined_labels(output_path: str):
            torch.cat((load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'params_test_dps_y_all.npy')),
                       load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'ret_test_dps_y_all.npy')),
                       load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'var_test_dps_y_all.npy'))))
+
+# Loading data for Type4Py model w/o identifiers
+def load_combined_train_data_woi(output_path: str):
+    return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_param_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_ret_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_var_train_datapoints_x.npy')))), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'params_train_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'ret_train_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'var_train_aval_types_dp.npy'))))
+
+def load_combined_valid_data_woi(output_path: str):
+    return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_param_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_ret_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_var_valid_datapoints_x.npy')))), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'params_valid_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'ret_valid_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'var_valid_aval_types_dp.npy'))))
+
+def load_combined_test_data_woi(output_path: str):
+    tk_p_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_param_test_datapoints_x.npy'))
+    tk_r_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_ret_test_datapoints_x.npy'))
+    tk_v_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_var_test_datapoints_x.npy'))
+
+    return torch.cat((tk_p_te, tk_r_te, tk_v_te)), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'params_test_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'ret_test_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'var_test_aval_types_dp.npy')))), \
+           (len(tk_p_te)-1, (len(tk_p_te)+len(tk_r_te))-1, (len(tk_p_te)+len(tk_r_te)+len(tk_v_te))-1)
+           # indexes of combined test data for separating between prediction tasks
+
+# Loading data for Type4Py model w/o code contexts
+def load_combined_train_data_woc(output_path: str):
+    return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_param_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_ret_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_var_train_datapoints_x.npy')))), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'params_train_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'ret_train_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'var_train_aval_types_dp.npy'))))
+
+def load_combined_valid_data_woc(output_path: str):
+    return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_param_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_ret_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_var_valid_datapoints_x.npy')))), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'params_valid_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'ret_valid_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'var_valid_aval_types_dp.npy'))))
+
+def load_combined_test_data_woc(output_path: str):
+    id_p_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_param_test_datapoints_x.npy'))
+    id_r_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_ret_test_datapoints_x.npy'))
+    id_v_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_var_test_datapoints_x.npy'))
+
+    return torch.cat((id_p_te, id_r_te, id_v_te)), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'params_test_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'ret_test_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'var_test_aval_types_dp.npy')))), \
+           (len(id_p_te)-1, (len(id_p_te)+len(id_r_te))-1, (len(id_p_te)+len(id_r_te)+len(id_v_te))-1)
+           # indexes of combined test data for separating between prediction tasks
+
+# Loading data for Type4Py model w/o visible type hints
+def load_combined_train_data_wov(output_path: str):
+    return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_param_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_ret_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_var_train_datapoints_x.npy')))), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_param_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_ret_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_var_train_datapoints_x.npy'))))
+
+def load_combined_valid_data_wov(output_path: str):
+    return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_param_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_ret_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_var_valid_datapoints_x.npy')))), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_param_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_ret_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_var_valid_datapoints_x.npy'))))
+
+def load_combined_test_data_wov(output_path: str):
+    id_p_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_param_test_datapoints_x.npy'))
+    id_r_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_ret_test_datapoints_x.npy'))
+    id_v_te = load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_var_test_datapoints_x.npy'))
+
+    return torch.cat((id_p_te, id_r_te, id_v_te)), \
+           torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_param_test_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_ret_test_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_var_test_datapoints_x.npy')))), \
+           (len(id_p_te)-1, (len(id_p_te)+len(id_r_te))-1, (len(id_p_te)+len(id_r_te)+len(id_v_te))-1)
+           # indexes of combined test data for separating between prediction tasks
+
 
 # Argument data
 def load_param_train_data(output_path: str):
@@ -121,7 +216,6 @@ def load_var_labels(output_path: str):
            load_flat_labels_tensors(join(output_path, 'vectors', 'valid', 'var_valid_dps_y_all.npy')), \
            load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'var_test_dps_y_all.npy'))
 
-
 def select_data(data, n):
     """
     Selects data points that are frequent more than n times
@@ -135,6 +229,156 @@ def select_data(data, n):
             mask[i] = True
     
     return mask
+
+def load_training_data_per_model(data_loading_funcs: dict, output_path: str,
+                                 no_batches: int, train_mode:bool=True,
+                                 no_workers:int=8) -> Tuple[DataLoader, DataLoader]:
+    """
+    Loads appropriate training data based on the model's type
+    """
+
+    # def find_common_types(y_all_train: torch.Tensor):
+    #     count_types = Counter(y_all_train.data.numpy())
+    #     return [t.item() for t in y_all_train if count_types[t.item()] >= 100]
+
+    load_data_t = time()
+    if data_loading_funcs['name'] == 'woi':
+        # without identifiers
+        X_tok_train, X_type_train = data_loading_funcs['train'](output_path)
+        X_tok_valid, X_type_valid = data_loading_funcs['valid'](output_path)
+        Y_all_train, Y_all_valid, _ = data_loading_funcs['labels'](output_path)
+
+        train_mask = select_data(Y_all_train, MIN_DATA_POINTS)
+        X_tok_train, X_type_train, Y_all_train = X_tok_train[train_mask], \
+             X_type_train[train_mask], Y_all_train[train_mask]
+
+        valid_mask = select_data(Y_all_valid, MIN_DATA_POINTS)
+        X_tok_valid, X_type_valid, Y_all_valid = X_tok_valid[valid_mask], \
+             X_type_valid[valid_mask], Y_all_valid[valid_mask]
+
+        triplet_data_train = TripletDataset(X_tok_train, X_type_train, labels=Y_all_train,
+                                      dataset_name=data_loading_funcs['name'], train_mode=train_mode)
+        triplet_data_valid = TripletDataset(X_tok_valid, X_type_valid, labels=Y_all_valid,
+                                            dataset_name=data_loading_funcs['name'],
+                                            train_mode=train_mode)
+    
+    elif data_loading_funcs['name'] == 'woc':
+        # without code tokens
+        X_id_train, X_type_train = data_loading_funcs['train'](output_path)
+        X_id_valid, X_type_valid = data_loading_funcs['valid'](output_path)
+        Y_all_train, Y_all_valid, _ = data_loading_funcs['labels'](output_path)
+
+        train_mask = select_data(Y_all_train, MIN_DATA_POINTS)
+        X_id_train, X_type_train, Y_all_train = X_id_train[train_mask], \
+                    X_type_train[train_mask], Y_all_train[train_mask]
+
+        valid_mask = select_data(Y_all_valid, MIN_DATA_POINTS)
+        X_id_valid, X_type_valid, Y_all_valid = X_id_valid[valid_mask], \
+                X_type_valid[valid_mask], Y_all_valid[valid_mask]
+
+        triplet_data_train = TripletDataset(X_id_train, X_type_train, labels=Y_all_train,
+                                      dataset_name=data_loading_funcs['name'], train_mode=train_mode)
+        triplet_data_valid = TripletDataset(X_id_valid, X_type_valid, labels=Y_all_valid,
+                                            dataset_name=data_loading_funcs['name'],
+                                            train_mode=train_mode)
+
+    elif data_loading_funcs['name'] == 'wov':
+        # without visible type hints
+        X_id_train, X_tok_train, = data_loading_funcs['train'](output_path)
+        X_id_valid, X_tok_valid, = data_loading_funcs['valid'](output_path)
+        Y_all_train, Y_all_valid, _ = data_loading_funcs['labels'](output_path)
+
+        train_mask = select_data(Y_all_train, MIN_DATA_POINTS)
+        X_id_train, X_tok_train, Y_all_train = X_id_train[train_mask], \
+                    X_tok_train[train_mask], Y_all_train[train_mask]
+
+        valid_mask = select_data(Y_all_valid, MIN_DATA_POINTS)
+        X_id_valid, X_tok_valid, Y_all_valid = X_id_valid[valid_mask], \
+                    X_tok_valid[valid_mask], Y_all_valid[valid_mask]
+
+        triplet_data_train = TripletDataset(X_id_train, X_tok_train, labels=Y_all_train,
+                                      dataset_name=data_loading_funcs['name'], train_mode=train_mode)
+        triplet_data_valid = TripletDataset(X_id_valid, X_tok_valid, labels=Y_all_valid,
+                                            dataset_name=data_loading_funcs['name'],
+                                            train_mode=train_mode)
+        
+    else:
+        # Complete model
+        X_id_train, X_tok_train, X_type_train = data_loading_funcs['train'](output_path)
+        X_id_valid, X_tok_valid, X_type_valid = data_loading_funcs['valid'](output_path)
+        Y_all_train, Y_all_valid, _ = data_loading_funcs['labels'](output_path)
+
+        train_mask = select_data(Y_all_train, MIN_DATA_POINTS)
+        X_id_train, X_tok_train, X_type_train, Y_all_train = X_id_train[train_mask], \
+                    X_tok_train[train_mask], X_type_train[train_mask], Y_all_train[train_mask]
+
+        valid_mask = select_data(Y_all_valid, MIN_DATA_POINTS)
+        X_id_valid, X_tok_valid, X_type_valid, Y_all_valid = X_id_valid[valid_mask], \
+                    X_tok_valid[valid_mask], X_type_valid[valid_mask], Y_all_valid[valid_mask]
+
+        triplet_data_train = TripletDataset(X_id_train, X_tok_train, X_type_train, labels=Y_all_train,
+                                      dataset_name=data_loading_funcs['name'], train_mode=train_mode)
+        triplet_data_valid = TripletDataset(X_id_valid, X_tok_valid, X_type_valid, labels=Y_all_valid,
+                                            dataset_name=data_loading_funcs['name'],
+                                            train_mode=train_mode)
+
+
+    logger.info(f"Loaded train and valid sets of the {data_loading_funcs['name']} dataset in {(time()-load_data_t)/60:.2f} min")
+
+    train_loader = DataLoader(triplet_data_train, batch_size=no_batches, shuffle=True,
+                              pin_memory=True, num_workers=no_workers)
+    valid_loader = DataLoader(triplet_data_valid, batch_size=no_batches, num_workers=no_workers)
+
+    return train_loader, valid_loader
+
+def load_test_data_per_model(data_loading_funcs: dict, output_path: str,
+                             no_batches: int, drop_last_batch:bool=False):
+    """
+    Loads appropriate training data based on the model's type
+    """
+
+    load_data_t = time()
+    if data_loading_funcs['name'] == 'woi':
+        # without identifiers
+        X_tok_test, X_type_test, t_idx = data_loading_funcs['test'](output_path)
+        _, _, Y_all_test = data_loading_funcs['labels'](output_path)
+
+
+        triplet_data_test = TripletDataset(X_tok_test, X_type_test, labels=Y_all_test,
+                                           dataset_name=data_loading_funcs['name'], train_mode=False)
+    
+    elif data_loading_funcs['name'] == 'woc':
+        # without code tokens
+        X_id_test, X_type_test, t_idx = data_loading_funcs['test'](output_path)
+        _, _, Y_all_test = data_loading_funcs['labels'](output_path)
+
+
+        triplet_data_test = TripletDataset(X_id_test, X_type_test, labels=Y_all_test,
+                                           dataset_name=data_loading_funcs['name'], train_mode=False)
+
+    elif data_loading_funcs['name'] == 'wov':
+        # without visible type hints
+        X_id_test, X_tok_test, t_idx = data_loading_funcs['test'](output_path)
+        _, _, Y_all_test = data_loading_funcs['labels'](output_path)
+
+
+        triplet_data_test = TripletDataset(X_id_test, X_tok_test, labels=Y_all_test,
+                                           dataset_name=data_loading_funcs['name'], train_mode=False)
+        
+    else:
+        # Complete model
+        X_id_test, X_tok_test, X_type_test, t_idx = data_loading_funcs['test'](output_path)
+        _, _, Y_all_test = data_loading_funcs['labels'](output_path)
+
+
+        triplet_data_test = TripletDataset(X_id_test, X_tok_test, X_type_test, labels=Y_all_test,
+                                           dataset_name=data_loading_funcs['name'], train_mode=False)
+
+
+    logger.info(f"Loaded the test set of the {data_loading_funcs['name']} dataset in {(time()-load_data_t)/60:.2f} min")
+
+    return DataLoader(triplet_data_test, batch_size=no_batches, num_workers=12, drop_last=drop_last_batch), t_idx
+
 
 
 class TripletDataset(torch.utils.data.Dataset):

--- a/type4py/data_loaders.py
+++ b/type4py/data_loaders.py
@@ -16,35 +16,47 @@ def load_flat_labels_tensors(filename):
 # Combined data
 def load_combined_train_data(output_path: str):
     return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_param_train_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_ret_train_datapoints_x.npy')))), \
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_ret_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_var_train_datapoints_x.npy')))), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_param_train_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_ret_train_datapoints_x.npy')))), \
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_ret_train_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_var_train_datapoints_x.npy')))), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'train', 'params_train_aval_types_dp.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'ret_train_aval_types_dp.npy'))))
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'ret_train_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'train', 'var_train_aval_types_dp.npy'))))
 
 def load_combined_valid_data(output_path: str):
     return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_param_valid_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_ret_valid_datapoints_x.npy')))), \
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_ret_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_var_valid_datapoints_x.npy')))), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_param_valid_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_ret_valid_datapoints_x.npy')))), \
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_ret_valid_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_var_valid_datapoints_x.npy')))), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'params_valid_aval_types_dp.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'ret_valid_aval_types_dp.npy'))))
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'ret_valid_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'var_valid_aval_types_dp.npy'))))
 
 def load_combined_test_data(output_path: str):
     return torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_param_test_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_ret_test_datapoints_x.npy')))), \
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_ret_test_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_var_test_datapoints_x.npy')))), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_param_test_datapoints_x.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_ret_test_datapoints_x.npy')))), \
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_ret_test_datapoints_x.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_var_test_datapoints_x.npy')))), \
            torch.cat((load_data_tensors_TW(join(output_path, 'vectors', 'test', 'params_test_aval_types_dp.npy')),
-                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'ret_test_aval_types_dp.npy'))))
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'ret_test_aval_types_dp.npy')),
+                      load_data_tensors_TW(join(output_path, 'vectors', 'test', 'var_test_aval_types_dp.npy'))))
 
 def load_combined_labels(output_path: str):
     return torch.cat((load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'params_train_dps_y_all.npy')),
-                      load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'ret_train_dps_y_all.npy')))), \
+                      load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'ret_train_dps_y_all.npy')),
+                      load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'var_train_dps_y_all.npy')))), \
            torch.cat((load_flat_labels_tensors(join(output_path, 'vectors', 'valid', 'params_valid_dps_y_all.npy')),
-                      load_flat_labels_tensors(join(output_path, 'vectors', 'valid', 'ret_valid_dps_y_all.npy')))), \
+                      load_flat_labels_tensors(join(output_path, 'vectors', 'valid', 'ret_valid_dps_y_all.npy')),
+                      load_flat_labels_tensors(join(output_path, 'vectors', 'valid', 'var_valid_dps_y_all.npy')))), \
            torch.cat((load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'params_test_dps_y_all.npy')),
-                      load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'ret_test_dps_y_all.npy'))))
+                      load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'ret_test_dps_y_all.npy')),
+                      load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'var_test_dps_y_all.npy'))))
 
 # Argument data
 def load_param_train_data(output_path: str):
@@ -87,6 +99,28 @@ def load_ret_labels(output_path: str):
     return load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'ret_train_dps_y_all.npy')), \
            load_flat_labels_tensors(join(output_path, 'vectors', 'valid', 'ret_valid_dps_y_all.npy')), \
            load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'ret_test_dps_y_all.npy'))
+
+# Variable data
+def load_var_train_data(output_path: str):
+    return load_data_tensors_TW(join(output_path, 'vectors', 'train', 'identifiers_var_train_datapoints_x.npy')), \
+           load_data_tensors_TW(join(output_path, 'vectors', 'train', 'tokens_var_train_datapoints_x.npy')), \
+           load_data_tensors_TW(join(output_path, 'vectors', 'train', 'var_train_aval_types_dp.npy'))
+
+def load_var_valid_data(output_path: str):
+    return load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'identifiers_var_valid_datapoints_x.npy')), \
+           load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'tokens_var_valid_datapoints_x.npy')), \
+           load_data_tensors_TW(join(output_path, 'vectors', 'valid', 'var_valid_aval_types_dp.npy'))
+
+def load_var_test_data(output_path: str):
+    return load_data_tensors_TW(join(output_path, 'vectors', 'test', 'identifiers_var_test_datapoints_x.npy')), \
+           load_data_tensors_TW(join(output_path, 'vectors', 'test', 'tokens_var_test_datapoints_x.npy')), \
+           load_data_tensors_TW(join(output_path, 'vectors', 'test', 'var_test_aval_types_dp.npy'))
+
+def load_var_labels(output_path: str):
+    return load_flat_labels_tensors(join(output_path, 'vectors', 'train', 'var_train_dps_y_all.npy')), \
+           load_flat_labels_tensors(join(output_path, 'vectors', 'valid', 'var_valid_dps_y_all.npy')), \
+           load_flat_labels_tensors(join(output_path, 'vectors', 'test', 'var_test_dps_y_all.npy'))
+
 
 def select_data(data, n):
     """

--- a/type4py/eval.py
+++ b/type4py/eval.py
@@ -1,7 +1,7 @@
 from type4py import logger
 from libsa4py.utils import load_json
 from os.path import join
-from sklearn.metrics import classification_report
+from sklearn.metrics import classification_report, precision_score
 from tqdm import tqdm
 from typing import List, Tuple
 import pickle
@@ -105,25 +105,21 @@ def eval_pred_dsl(test_pred: List[dict], common_types, tasks: set, top_n=10):
     param_type_match = r'(.+)\[(.+)\]'
 
     def pred_types_fix(y_true: str, y_pred: List[Tuple[str, int]]):
-        for p, _ in y_pred[:top_n]:
+        for i, (p, _) in enumerate(y_pred[:top_n]):
             if p == y_true:
-                return p
+                return p, 1/(i+1)
 
-        return y_pred[0][0]
-
-    # def is_param_correct(y: str, p: str) -> int:
-    #     param_type_match = r'(.+)\[(.+)\]'
-    #     if re.match(param_type_match, p):
-    #         if re.match(param_type_match, y).group(1) == re.match(param_type_match, p).group(1):
-    #             return 1
-  
-    #     return 0
+        return y_pred[0][0], 0.0
 
     def is_param_correct(true_param_type: str, pred_types: np.array):
         no_match = 0
         for p in pred_types:
             if re.match(param_type_match, p):
                 if re.match(param_type_match, true_param_type).group(1) == re.match(param_type_match, p).group(1):
+                    no_match += 1
+                    break
+            else:
+                if re.match(param_type_match, true_param_type).group(1).lower() == p.lower():
                     no_match += 1
                     break
         
@@ -144,18 +140,16 @@ def eval_pred_dsl(test_pred: List[dict], common_types, tasks: set, top_n=10):
     all_param_rare_types = 0
     corr_param_rare_types = 0
 
-    y_true = []
-    y_pred = []
-
+    mrr = []
+   
     for p in tqdm(test_pred, total=len(test_pred)):
 
         if p['task'] not in tasks:
             continue
 
-        top_n_pred = pred_types_fix(p['original_type'], p['predictions'])
-        y_true.append(p['original_type'])
-        y_pred.append(top_n_pred)
-
+        top_n_pred, r = pred_types_fix(p['original_type'], p['predictions'])
+        mrr.append(r)
+        
         if p['original_type'] in ubiquitous_types:
             all_ubiq_types += 1
             if p['original_type'] == top_n_pred:
@@ -183,50 +177,20 @@ def eval_pred_dsl(test_pred: List[dict], common_types, tasks: set, top_n=10):
     logger.info(f"Type4Py - {tasks} - Parametric match - common: {(corr_param_common_types + corr_common_types) / all_common_types * 100.0:.2f}%")
     logger.info(f"Type4Py - {tasks} - Parametric match - rare: {(corr_param_rare_types+corr_rare_types) / all_rare_types * 100.0:.2f}%")
     
-    # res = classification_report(y_true, y_pred, output_dict=True)
+    logger.info(f"Type4Py - Mean reciprocal rank {np.mean(mrr)*100:.2f}")
+   
+    return np.mean(mrr)*100
 
-    # logger.info("F1-score: %.2f | Recall: %.2f | Precision: %.2f" % (res['f1-score']*100,
-    #                                                            res['recall']*100,
-    #                                                            res['precision']*100))
+def evaluate(output_path: str, data_name: str, tasks: str, top_n: int=10):
 
-def evaluate(output_path: str, data_loading_funcs: dict, tasks: str, top_n: int=10):
-
-    logger.info(f"Evaluating Type4Py model for {data_loading_funcs['name']} prediction task")
+    logger.info(f"Evaluating the Type4Py {data_name} model for {tasks} prediction task")
     logger.info(f"*************************************************************************")
     # Loading label encoder andd common types
-    test_pred = load_json(join(output_path, 'type4py_test_predictions.json'))
+    test_pred = load_json(join(output_path, f'type4py_{data_name}_test_predictions.json'))
     le_all = pickle.load(open(join(output_path, "label_encoder_all.pkl"), 'rb'))
     common_types = pickle.load(open(join(output_path, "combined_common_types.pkl"), 'rb'))
     common_types = set(le_all.inverse_transform(list(common_types)))
     ubiquitous_types = {'str', 'int', 'list', 'bool', 'float'}
-    #ubiquitous_types = set(le_all.transform(list(ubiquitous_types)))
     common_types = common_types - ubiquitous_types
-
-
-    # pred_test_embed = np.load(join(output_path, f"type4py_{data_loading_funcs['name']}_pred.npy"), allow_pickle=True)
-    # embed_test_labels = np.load(join(output_path, f"type4py_{data_loading_funcs['name']}_true.npy"))
-
-    # acc_all, acc_ubiq, acc_common, acc_rare, com_mask, rare_mask = eval_type_embed(pred_test_embed,
-    #                                                                  embed_test_labels,
-    #                                                                  ubiquitous_types,
-    #                                                                  common_types, top_n)
-
-    # logger.info("Type4Py - Exact match - all: %.2f%%" % acc_all)
-    # logger.info("Type4Py - Exact match - ubiquitous: %.2f%%" % acc_ubiq)
-    # logger.info("Type4Py - Exact match - common: %.2f%%" % acc_common)
-    # logger.info("Type4Py - Exact match - rare: %.2f%%" % acc_rare)
-
-    # acc_all_param, acc_common_param, acc_rare_param = eval_parametric_match(pred_test_embed,
-    #                                                                         embed_test_labels,
-    #                                                                         ubiquitous_types,
-    #                                                                         common_types, le_all, top_n)
-
-    # logger.info("Type4Py - Parametric match - all: %.2f%%" % acc_all_param)
-    # logger.info("Type4Py - Parametric match - common: %.2f%%" % acc_common_param)
-    # logger.info("Type4Py - Parametric match - rare: %.2f%%" % acc_rare_param)
-
+    
     eval_pred_dsl(test_pred, common_types, tasks, top_n=top_n)
-
-    # logger.info("F1-score: %.2f | Recall: %.2f | Precision: %.2f" % (res['f1-score']*100,
-    #                                                            res['recall']*100,
-    #                                                            res['precision']*100))

--- a/type4py/eval.py
+++ b/type4py/eval.py
@@ -1,7 +1,9 @@
 from type4py import logger
+from libsa4py.utils import load_json
 from os.path import join
 from sklearn.metrics import classification_report
 from tqdm import tqdm
+from typing import List, Tuple
 import pickle
 import re
 import numpy as np
@@ -96,60 +98,135 @@ def eval_parametric_match(y_pred: np.array, y_true: np.array, ubiquitous_types: 
     return (corr_ubiq_types + corr_param_common_types + corr_param_rare_types) / len(y_pred) * 100.0, \
             corr_param_common_types / all_param_common_types * 100.0, corr_param_rare_types / all_param_rare_types * 100.0
 
-def eval_pred_dsl(y_true, y_pred, top_n=10):
+def eval_pred_dsl(test_pred: List[dict], common_types, tasks: set, top_n=10):
     """
     Computes evaluation metrics such as recall, precision and f1-score
     """
+    param_type_match = r'(.+)\[(.+)\]'
 
-    def pred_types_fix(y_true, y_pred):
-        best_predicted = np.empty_like(y_true)
-        for i in range(y_true.shape[0]):
-            if y_true[i] in y_pred[i][:top_n]:
-                best_predicted[i] = y_true[i]
-            else:
-                best_predicted[i] = y_pred[i][0]
+    def pred_types_fix(y_true: str, y_pred: List[Tuple[str, int]]):
+        for p, _ in y_pred[:top_n]:
+            if p == y_true:
+                return p
 
-        return best_predicted
+        return y_pred[0][0]
+
+    # def is_param_correct(y: str, p: str) -> int:
+    #     param_type_match = r'(.+)\[(.+)\]'
+    #     if re.match(param_type_match, p):
+    #         if re.match(param_type_match, y).group(1) == re.match(param_type_match, p).group(1):
+    #             return 1
+  
+    #     return 0
+
+    def is_param_correct(true_param_type: str, pred_types: np.array):
+        no_match = 0
+        for p in pred_types:
+            if re.match(param_type_match, p):
+                if re.match(param_type_match, true_param_type).group(1) == re.match(param_type_match, p).group(1):
+                    no_match += 1
+                    break
+        
+        return no_match
+
+    ubiquitous_types = {'str', 'int', 'list', 'bool', 'float'}
+    common_types = common_types - ubiquitous_types
+
+    all_ubiq_types = 0
+    corr_ubiq_types = 0
+    all_common_types = 0
+    corr_common_types = 0
+    all_rare_types = 0
+    corr_rare_types = 0
+
+    all_param_common_types = 0
+    corr_param_common_types = 0
+    all_param_rare_types = 0
+    corr_param_rare_types = 0
+
+    y_true = []
+    y_pred = []
+
+    for p in tqdm(test_pred, total=len(test_pred)):
+
+        if p['task'] not in tasks:
+            continue
+
+        top_n_pred = pred_types_fix(p['original_type'], p['predictions'])
+        y_true.append(p['original_type'])
+        y_pred.append(top_n_pred)
+
+        if p['original_type'] in ubiquitous_types:
+            all_ubiq_types += 1
+            if p['original_type'] == top_n_pred:
+                corr_ubiq_types += 1
+        elif p['original_type'] in common_types:
+            all_common_types += 1
+            if p['original_type'] == top_n_pred:
+                corr_common_types += 1
+            elif p['is_parametric']:
+                corr_param_common_types += is_param_correct(p['original_type'], [i for i, _ in p['predictions'][:top_n]])
+        else:
+            all_rare_types += 1
+            if p['original_type'] == top_n_pred:
+                corr_rare_types += 1
+            elif p['is_parametric']:
+                corr_param_rare_types += is_param_correct(p['original_type'], [i for i, _ in p['predictions'][:top_n]])
+
+    tasks = 'Combined' if tasks == {'Parameter', 'Return', 'Variable'} else list(tasks)[0]
+    logger.info(f"Type4Py - {tasks} - Exact match - all: {(corr_ubiq_types + corr_common_types + corr_rare_types) / (all_ubiq_types+all_common_types+all_rare_types) * 100.0:.2f}%")
+    logger.info(f"Type4Py - {tasks} - Exact match - ubiquitous: {corr_ubiq_types / all_ubiq_types * 100.0:.2f}%")
+    logger.info(f"Type4Py - {tasks} - Exact match - common: {corr_common_types / all_common_types * 100.0:.2f}%")
+    logger.info(f"Type4Py - {tasks} - Exact match - rare: {corr_rare_types / all_rare_types * 100.0:.2f}%")
+
+    logger.info(f"Type4Py - {tasks} - Parametric match - all: {(corr_ubiq_types + corr_common_types + corr_rare_types + corr_param_common_types + corr_param_rare_types) / (all_ubiq_types+all_common_types+all_rare_types) * 100.0:.2f}%")
+    logger.info(f"Type4Py - {tasks} - Parametric match - common: {(corr_param_common_types + corr_common_types) / all_common_types * 100.0:.2f}%")
+    logger.info(f"Type4Py - {tasks} - Parametric match - rare: {(corr_param_rare_types+corr_rare_types) / all_rare_types * 100.0:.2f}%")
     
-    y_pred_fixed = pred_types_fix(y_true, y_pred)
-    report = classification_report(y_true, y_pred_fixed, output_dict=True)
+    # res = classification_report(y_true, y_pred, output_dict=True)
 
-    return report['weighted avg']
+    # logger.info("F1-score: %.2f | Recall: %.2f | Precision: %.2f" % (res['f1-score']*100,
+    #                                                            res['recall']*100,
+    #                                                            res['precision']*100))
 
-def evaluate(output_path: str, data_loading_funcs: dict, top_n: int=10):
+def evaluate(output_path: str, data_loading_funcs: dict, tasks: str, top_n: int=10):
 
     logger.info(f"Evaluating Type4Py model for {data_loading_funcs['name']} prediction task")
     logger.info(f"*************************************************************************")
     # Loading label encoder andd common types
+    test_pred = load_json(join(output_path, 'type4py_test_predictions.json'))
     le_all = pickle.load(open(join(output_path, "label_encoder_all.pkl"), 'rb'))
-    common_types = pickle.load(open(join(output_path, f"{data_loading_funcs['name']}_common_types.pkl"), 'rb'))
-    ubiquitous_types = set(le_all.transform(['str', 'int', 'list', 'bool', 'float']))
+    common_types = pickle.load(open(join(output_path, "combined_common_types.pkl"), 'rb'))
+    common_types = set(le_all.inverse_transform(list(common_types)))
+    ubiquitous_types = {'str', 'int', 'list', 'bool', 'float'}
+    #ubiquitous_types = set(le_all.transform(list(ubiquitous_types)))
     common_types = common_types - ubiquitous_types
 
-    pred_test_embed = np.load(join(output_path, f"type4py_{data_loading_funcs['name']}_pred.npy"), allow_pickle=True)
-    embed_test_labels = np.load(join(output_path, f"type4py_{data_loading_funcs['name']}_true.npy"))
 
-    acc_all, acc_ubiq, acc_common, acc_rare, com_mask, rare_mask = eval_type_embed(pred_test_embed,
-                                                                     embed_test_labels,
-                                                                     ubiquitous_types,
-                                                                     common_types, top_n)
+    # pred_test_embed = np.load(join(output_path, f"type4py_{data_loading_funcs['name']}_pred.npy"), allow_pickle=True)
+    # embed_test_labels = np.load(join(output_path, f"type4py_{data_loading_funcs['name']}_true.npy"))
 
-    logger.info("Type4Py - Exact match - all: %.2f%%" % acc_all)
-    logger.info("Type4Py - Exact match - ubiquitous: %.2f%%" % acc_ubiq)
-    logger.info("Type4Py - Exact match - common: %.2f%%" % acc_common)
-    logger.info("Type4Py - Exact match - rare: %.2f%%" % acc_rare)
+    # acc_all, acc_ubiq, acc_common, acc_rare, com_mask, rare_mask = eval_type_embed(pred_test_embed,
+    #                                                                  embed_test_labels,
+    #                                                                  ubiquitous_types,
+    #                                                                  common_types, top_n)
 
-    acc_all_param, acc_common_param, acc_rare_param = eval_parametric_match(pred_test_embed,
-                                                                            embed_test_labels,
-                                                                            ubiquitous_types,
-                                                                            common_types, le_all, top_n)
+    # logger.info("Type4Py - Exact match - all: %.2f%%" % acc_all)
+    # logger.info("Type4Py - Exact match - ubiquitous: %.2f%%" % acc_ubiq)
+    # logger.info("Type4Py - Exact match - common: %.2f%%" % acc_common)
+    # logger.info("Type4Py - Exact match - rare: %.2f%%" % acc_rare)
 
-    logger.info("Type4Py - Parametric match - all: %.2f%%" % acc_all_param)
-    logger.info("Type4Py - Parametric match - common: %.2f%%" % acc_common_param)
-    logger.info("Type4Py - Parametric match - rare: %.2f%%" % acc_rare_param)
+    # acc_all_param, acc_common_param, acc_rare_param = eval_parametric_match(pred_test_embed,
+    #                                                                         embed_test_labels,
+    #                                                                         ubiquitous_types,
+    #                                                                         common_types, le_all, top_n)
 
-    res = eval_pred_dsl(embed_test_labels, pred_test_embed, top_n=top_n)
+    # logger.info("Type4Py - Parametric match - all: %.2f%%" % acc_all_param)
+    # logger.info("Type4Py - Parametric match - common: %.2f%%" % acc_common_param)
+    # logger.info("Type4Py - Parametric match - rare: %.2f%%" % acc_rare_param)
 
-    logger.info("F1-score: %.2f | Recall: %.2f | Precision: %.2f" % (res['f1-score']*100,
-                                                               res['recall']*100,
-                                                               res['precision']*100))
+    eval_pred_dsl(test_pred, common_types, tasks, top_n=top_n)
+
+    # logger.info("F1-score: %.2f | Recall: %.2f | Precision: %.2f" % (res['f1-score']*100,
+    #                                                            res['recall']*100,
+    #                                                            res['precision']*100))

--- a/type4py/learn.py
+++ b/type4py/learn.py
@@ -2,13 +2,14 @@ from type4py.data_loaders import select_data, TripletDataset
 from type4py.vectorize import AVAILABLE_TYPES_NUMBER, W2V_VEC_LENGTH
 from type4py.eval import eval_type_embed
 from type4py.utils import load_json
-from type4py import logger
+from type4py import logger, MIN_DATA_POINTS, KNN_TREE_SIZE
 from torch.utils.data import DataLoader
 from typing import Tuple
 from collections import Counter
 from os.path import join
 from time import time
 from annoy import AnnoyIndex
+from tqdm import tqdm
 import numpy as np
 import torch.nn as nn
 import torch
@@ -28,7 +29,9 @@ def load_model_params(params_file_path: str=None) -> dict:
                 'margin': 2.0, 'k': 10}
 
 class Type4Py(nn.Module):
- 
+    """
+    Complete model
+    """
     def __init__(self, input_size: int, hidden_size: int, aval_type_size: int,
                  num_layers: int, output_size: int, dropout_rate: float):
         super(Type4Py, self).__init__()
@@ -67,6 +70,129 @@ class Type4Py(nn.Module):
         x = self.linear(x)
         return x
 
+class Type4PyWOI(nn.Module):
+    """
+    Type4Py without the identifier RNN
+    """
+    def __init__(self, input_size: int, hidden_size: int, aval_type_size: int,
+                 num_layers: int, output_size: int, dropout_rate: float):
+        super(Type4PyWOI, self).__init__()
+
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.aval_type_size = aval_type_size
+        self.num_layers = num_layers
+        self.output_size = output_size
+
+        self.lstm_tok = nn.LSTM(self.input_size, self.hidden_size, self.num_layers, batch_first=True,
+                                bidirectional=True)
+
+        self.linear = nn.Linear(self.hidden_size * 2 + self.aval_type_size, self.output_size)
+
+        self.dropout = nn.Dropout(p=dropout_rate)
+
+    def forward(self, x_tok, x_type):
+
+        # Using dropout on input sequences
+        x_tok = self.dropout(x_tok)
+
+        # Flattens LSTMs weights for data-parallelism in multi-GPUs config
+        self.lstm_tok.flatten_parameters()
+
+        x_tok, _ = self.lstm_tok(x_tok)
+
+        # Decode the hidden state of the last time step
+        x_tok = x_tok[:, -1, :]
+
+        x = torch.cat((x_tok, x_type), 1)
+
+        x = self.linear(x)
+        return x
+
+class Type4PyWOC(nn.Module):
+    """
+    Type4Py without code context
+    """
+    def __init__(self, input_size: int, hidden_size: int, aval_type_size: int,
+                 num_layers: int, output_size: int, dropout_rate: float):
+        super(Type4PyWOC, self).__init__()
+
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.aval_type_size = aval_type_size
+        self.num_layers = num_layers
+        self.output_size = output_size
+
+        self.lstm_id = nn.LSTM(self.input_size, self.hidden_size, self.num_layers, batch_first=True,
+                               bidirectional=True)
+
+        self.linear = nn.Linear(self.hidden_size * 2 + self.aval_type_size, self.output_size)
+
+        self.dropout = nn.Dropout(p=dropout_rate)
+
+    def forward(self, x_id, x_type):
+
+        # Using dropout on input sequences
+        x_id = self.dropout(x_id)
+
+        # Flattens LSTMs weights for data-parallelism in multi-GPUs config
+        self.lstm_id.flatten_parameters()
+
+        x_id, _ = self.lstm_id(x_id)
+
+        # Decode the hidden state of the last time step
+        x_id = x_id[:, -1, :]
+
+        x = torch.cat((x_id, x_type), 1)
+
+        x = self.linear(x)
+        return x
+
+class Type4PyWOV(nn.Module):
+    """
+    Type4Py model without visible type hints
+    """
+
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int, output_size: int,
+                 dropout_rate: float):
+        super(Type4PyWOV, self).__init__()
+
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.output_size = output_size
+
+        self.lstm_id = nn.LSTM(self.input_size, self.hidden_size, self.num_layers, batch_first=True,
+                               bidirectional=True)
+        self.lstm_tok = nn.LSTM(self.input_size, self.hidden_size, self.num_layers, batch_first=True,
+                                bidirectional=True)
+
+        self.linear = nn.Linear(self.hidden_size * 2 * 2, self.output_size)
+
+        self.dropout = nn.Dropout(p=dropout_rate)
+
+    def forward(self, x_id, x_tok):
+
+        # Using dropout on input sequences
+        x_id = self.dropout(x_id)
+        x_tok = self.dropout(x_tok)
+
+        # Flattens LSTMs weights for data-parallelism in multi-GPUs config
+        self.lstm_id.flatten_parameters()
+        self.lstm_tok.flatten_parameters()
+
+        x_id, _ = self.lstm_id(x_id)
+        x_tok, _ = self.lstm_tok(x_tok)
+
+        # Decode the hidden state of the last time step
+        x_id = x_id[:, -1, :]
+        x_tok = x_tok[:, -1, :]
+
+        x = torch.cat((x_id, x_tok), 1)
+
+        x = self.linear(x)
+        return x
+
 class TripletModel(nn.Module):
     """
     A model with Triplet loss for similarity learning
@@ -79,40 +205,44 @@ class TripletModel(nn.Module):
         """
         A triplet consists of anchor, positive examples and negative examples
         """
-        return self.model(*(s.to(DEVICE) for s in a)), \
-               self.model(*(s.to(DEVICE) for s in p)), \
-               self.model(*(s.to(DEVICE) for s in n))
+        # return self.model(*(s.to(DEVICE) for s in a)), \
+        #        self.model(*(s.to(DEVICE) for s in p)), \
+        #        self.model(*(s.to(DEVICE) for s in n))
 
-def create_knn_index(train_types_embed: np.array, valid_types_embed: np.array, type_embed_dim:int,
-                     tree_size: int) -> AnnoyIndex:
+        return self.model(*(s for s in a)), \
+               self.model(*(s for s in p)), \
+               self.model(*(s for s in n))
+
+def create_knn_index(train_types_embed: np.array, valid_types_embed: np.array, type_embed_dim:int) -> AnnoyIndex:
     """
     Creates KNNs index for given type embedding vectors
     """
 
     annoy_idx = AnnoyIndex(type_embed_dim, 'euclidean')
 
-    for i, v in enumerate(train_types_embed):
+    for i, v in enumerate(tqdm(train_types_embed, total=len(train_types_embed),
+                          desc="KNN index")):
         annoy_idx.add_item(i, v)
 
     if valid_types_embed is not None:
         for i, v in enumerate(valid_types_embed):
             annoy_idx.add_item(len(train_types_embed) + i, v)
 
-    annoy_idx.build(tree_size)
+    annoy_idx.build(KNN_TREE_SIZE)
     return annoy_idx
 
 def train_loop_dsl(model: TripletModel, criterion, optimizer, train_data_loader: DataLoader,
                    valid_data_loader: DataLoader, learning_rate: float, epochs: int,
-                   common_types: set, model_path: str):
+                   ubiquitous_types: str, common_types: set, model_path: str):
     from type4py.predict import predict_type_embed
     
     for epoch in range(1, epochs + 1):
         model.train()
-        epoch_start_t = time()
+        #epoch_start_t = time()
         total_loss = 0
 
-        for batch_i, (anchor, positive_ex, negative_ex) in enumerate(train_data_loader):
-
+        for batch_i, (anchor, positive_ex, negative_ex) in enumerate(tqdm(train_data_loader,
+                                                                     total=len(train_data_loader), desc=f"Epoch {epoch}")):
             anchor, _ = anchor[0], anchor[1]
             positive_ex, _ = positive_ex[0], positive_ex[1]
             negative_ex, _ = negative_ex[0], negative_ex[1]
@@ -127,18 +257,20 @@ def train_loop_dsl(model: TripletModel, criterion, optimizer, train_data_loader:
 
             total_loss += loss.item()
          
-        logger.info(f"epoch: {epoch} train loss: {total_loss} in {(time() - epoch_start_t) / 60.0:.2f} min.")
+        logger.info(f"epoch: {epoch} train loss: {total_loss}")
 
-        if epoch % 5 == 0:
-            valid_start = time()
-            valid_loss, valid_all_acc = compute_validation_loss_dsl(model, criterion, train_data_loader, valid_data_loader,
-                                                                    predict_type_embed, common_types)
-            logger.info(f"epoch: {epoch} valid loss: {valid_loss} in {(time() - valid_start) / 60.0:.2f} min.")
-            #torch.save(model.module, join(model_path, f"{model.module.tw_embed_model.__class__.__name__}_{train_data_loader.dataset.dataset_name}_e{epoch}_{datetime.now().strftime('%b%d_%H-%M-%S')}.pt"))
+        if valid_data_loader is not None:
+            if epoch % 5 == 0:
+                logger.info("Evaluating on validation set")
+                valid_start = time()
+                valid_loss, valid_all_acc = compute_validation_loss_dsl(model, criterion, train_data_loader, valid_data_loader,
+                                                                        predict_type_embed, ubiquitous_types, common_types)
+                logger.info(f"epoch: {epoch} valid loss: {valid_loss} in {(time() - valid_start) / 60.0:.2f} min.")
+                #torch.save(model.module, join(model_path, f"{model.module.tw_embed_model.__class__.__name__}_{train_data_loader.dataset.dataset_name}_e{epoch}_{datetime.now().strftime('%b%d_%H-%M-%S')}.pt"))
 
 def compute_validation_loss_dsl(model: TripletModel, criterion, train_valid_loader: DataLoader,
                                 valid_data_loader: DataLoader, pred_func: callable,
-                                 common_types: set) -> Tuple[float, float]:
+                                ubiquitous_types:str, common_types: set) -> Tuple[float, float]:
     """
     Computes validation loss for Deep Similarity Learning-based approach
     """
@@ -157,13 +289,17 @@ def compute_validation_loss_dsl(model: TripletModel, criterion, train_valid_load
         computed_embed_batches_valid = []
         computed_embed_labels_valid = []
 
-        for batch_i, (a, p, n) in enumerate(train_valid_loader):
+        for batch_i, (a, p, n) in enumerate(tqdm(train_valid_loader,
+                                            total=len(train_valid_loader),
+                                            desc="Type Cluster - Train set")):
             #a_id, a_tok, a_cm, a_avl = a[0]
             output_a = main_model_forward(*(s.to(DEVICE) for s in a[0]))
             computed_embed_batches_train.append(output_a.data.cpu().numpy())
             computed_embed_labels_train.append(a[1].data.cpu().numpy())
         
-        for batch_i, (anchor, positive_ex, negative_ex) in enumerate(valid_data_loader):
+        for batch_i, (anchor, positive_ex, negative_ex) in enumerate(tqdm(valid_data_loader,
+                                                                     total=len(valid_data_loader),
+                                                                     desc="Type Cluster - Valid set")):
             positive_ex, _ = positive_ex[0], positive_ex[1]
             negative_ex, _ = negative_ex[0], negative_ex[1]
 
@@ -175,12 +311,12 @@ def compute_validation_loss_dsl(model: TripletModel, criterion, train_valid_load
             computed_embed_batches_valid.append(output_a.data.cpu().numpy())
             computed_embed_labels_valid.append(anchor[1].data.cpu().numpy())
 
-        annoy_index = create_knn_index(np.vstack(computed_embed_batches_train), None, computed_embed_batches_train[0].shape[1], 20)
+        annoy_index = create_knn_index(np.vstack(computed_embed_batches_train), None, computed_embed_batches_train[0].shape[1])
         pred_valid_embed, _ = pred_func(np.vstack(computed_embed_batches_valid), np.hstack(computed_embed_labels_train),
                                                                 annoy_index, 10)
-        acc_all, acc_common, acc_rare, _, _ = eval_type_embed(pred_valid_embed, np.hstack(computed_embed_labels_valid),
-                                                           common_types, 10)
-        logger.info("E-All: %.2f | E-Comm: %.2f | E-rare: %.2f" % (acc_all, acc_common, acc_rare))
+        acc_all, acc_ubiq, acc_common, acc_rare, _, _ = eval_type_embed(pred_valid_embed, np.hstack(computed_embed_labels_valid),
+                                                              ubiquitous_types, common_types, 10)
+        logger.info("E-All: %.2f | E-Ubiq: %.2f | E-Comm: %.2f | E-Rare: %.2f" % (acc_all, acc_ubiq, acc_common, acc_rare))
 
     return valid_total_loss, acc_all
 
@@ -199,18 +335,25 @@ def train(output_path: str, data_loading_funcs: dict, model_params_path=None):
     logger.info(f"No. of validation samples: {len(X_id_valid):,}")
 
     # Select data points which has at least frequency of 3 or more (for similarity learning)
-    train_mask = select_data(Y_all_train, 3)
+    train_mask = select_data(Y_all_train, MIN_DATA_POINTS)
     X_id_train, X_tok_train, X_type_train, Y_all_train = X_id_train[train_mask], \
                 X_tok_train[train_mask], X_type_train[train_mask], Y_all_train[train_mask]
 
-    valid_mask = select_data(Y_all_valid, 3)
+    valid_mask = select_data(Y_all_valid, MIN_DATA_POINTS)
     X_id_valid, X_tok_valid, X_type_valid, Y_all_valid = X_id_valid[valid_mask], \
                 X_tok_valid[valid_mask], X_type_valid[valid_mask], Y_all_valid[valid_mask]
 
+    # Loading label encoder and finding ubiquitous & common types
+    le_all = pickle.load(open(join(output_path, "label_encoder_all.pkl"), 'rb'))
     count_types = Counter(Y_all_train.data.numpy())
     common_types = [t.item() for t in Y_all_train if count_types[t.item()] >= 100]
-    logger.info("Percentage of common types: %.2f%%" % (len(common_types) / Y_all_train.shape[0]*100.0))
-    common_types = set(common_types)
+    ubiquitous_types = set(le_all.transform(['str', 'int', 'list', 'bool', 'float']))
+    common_types = set(common_types) - ubiquitous_types
+
+    logger.info("Percentage of ubiquitous types: %.2f%%" % (len([t.item() for t in \
+        Y_all_train if t.item() in ubiquitous_types]) / Y_all_train.shape[0]*100.0))
+    logger.info("Percentage of common types: %.2f%%" % (len([t.item() for t in \
+        Y_all_train if t.item() in common_types]) / Y_all_train.shape[0]*100.0))
 
     with open(join(output_path, f"{data_loading_funcs['name']}_common_types.pkl"), 'wb') as f:
         pickle.dump(common_types, f)
@@ -221,11 +364,10 @@ def train(output_path: str, data_loading_funcs: dict, model_params_path=None):
     # Batch loaders
     train_loader = DataLoader(TripletDataset(X_id_train, X_tok_train, X_type_train, \
                           labels=Y_all_train, dataset_name=data_loading_funcs['name'], train_mode=True), \
-                          batch_size=model_params['batches'], shuffle=True, pin_memory=True,
-                          num_workers=4)
+                          batch_size=model_params['batches'], shuffle=True, pin_memory=True, num_workers=12)
     valid_loader = DataLoader(TripletDataset(X_id_valid, X_tok_valid, X_type_valid, \
                             labels=Y_all_valid, dataset_name=data_loading_funcs['name'], \
-                                            train_mode=True), batch_size=model_params['batches'], num_workers=4)
+                                            train_mode=True), batch_size=model_params['batches'])
 
     # Loading the model
     model = Type4Py(W2V_VEC_LENGTH, model_params['hidden_size'], AVAILABLE_TYPES_NUMBER, model_params['layers'],
@@ -238,8 +380,8 @@ def train(output_path: str, data_loading_funcs: dict, model_params_path=None):
     optimizer = torch.optim.Adam(model.parameters(), lr=model_params['lr'])
 
     train_t = time()
-    train_loop_dsl(model, criterion, optimizer, train_loader, valid_loader, model_params['lr'],
-                   model_params['epochs'], common_types, None)
+    train_loop_dsl(model, criterion, optimizer, train_loader, None, model_params['lr'],
+                   model_params['epochs'], ubiquitous_types, common_types, None)
     logger.info("Training finished in %.2f min" % ((time()-train_t) / 60))
 
     # Saving the model

--- a/type4py/model_params.json
+++ b/type4py/model_params.json
@@ -1,9 +1,10 @@
 {
-    "epochs": 5,
+    "epochs": 25,
     "lr": 0.002,
     "dr": 0.25,
     "output_size": 4096,
     "batches": 2536,
+    "batches_test": 8192,
     "layers": 1,
     "hidden_size": 512,
     "margin": 2.0,

--- a/type4py/preprocess.py
+++ b/type4py/preprocess.py
@@ -1,8 +1,9 @@
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 from type4py import logger
-from libsa4py.merge import merge_jsons_to_dict, create_dataframe_fns
+from libsa4py.merge import merge_jsons_to_dict, create_dataframe_fns, create_dataframe_vars
 from libsa4py.utils import list_files
+from typing import Tuple
 from ast import literal_eval
 from collections import Counter
 from tqdm import tqdm
@@ -17,34 +18,56 @@ logger.name = __name__
 # Precompile often used regex
 first_cap_regex = re.compile('(.)([A-Z][a-z]+)')
 all_cap_regex = re.compile('([a-z0-9])([A-Z])')
+sub_regex = r'typing\.|typing_extensions\.|t\.|builtins\.'
 
-def make_types_consistent(df_all: pd.DataFrame) -> pd.DataFrame:
+
+def make_types_consistent(df_all: pd.DataFrame, df_vars: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Removes typing module from type annotations
     """
-    
-    df_all['return_type'] = df_all['return_type'].apply(lambda x: re.sub(r'typing\.|t\.|builtins\.', "", str(x)) if x else x)
-    df_all['arg_types'] = df_all['arg_types'].apply(lambda x: str([re.sub(r'typing\.|t\.|builtins\.', "", t) \
-                                                       if t else t for t in literal_eval(x)]))
-    
-    return df_all
 
-def resolve_type_aliasing(df_all: pd.DataFrame) -> pd.DataFrame:
+    def remove_quote_types(t: str):
+        s = re.search(r'^\'(.+)\'$', t)
+        if bool(s):
+            return s.group(1)
+        else:
+            #print(t)
+            return t
+    
+    
+    df_all['return_type'] = df_all['return_type'].apply(lambda x: re.sub(sub_regex, "", str(x)) if x else x)
+    df_all['arg_types'] = df_all['arg_types'].apply(lambda x: str([re.sub(sub_regex, "", t) \
+                                                       if t else t for t in literal_eval(x)]))
+    df_all['return_type'] = df_all['return_type'].apply(remove_quote_types)
+    df_all['arg_types'] = df_all['arg_types'].apply(lambda x: str([remove_quote_types(t) if t else t for t in literal_eval(x)]))
+
+    df_vars['var_type'] = df_vars['var_type'].apply(lambda x: re.sub(sub_regex, "", str(x)))
+    df_vars['var_type'] = df_vars['var_type'].apply(remove_quote_types)
+    
+    return df_all, df_vars
+
+def resolve_type_aliasing(df_all: pd.DataFrame, df_vars: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Resolves type aliasing and mappings. e.g. `[]` -> `list`
     """
 
-    def resolve_alias(alias_dict: dict, t: str):
-        for t_alias in alias_dict:
+    # TODO: These aliases may occur in a parametric type, not neccessarily at the beginning. E.g., List[{}] -> List[dict]
+    type_aliases = {'^{}$': 'dict', '^Dict$': 'dict', '^Set$': 'set', '^Tuple$': 'tuple',
+                    '\\bText\\b': 'str', '^\[\]$': 'list', '^\[{}\]$': 'List[dict]',
+                    '^List\[\]$': 'list', '^Set\[\]$': 'set', '^Tuple\[\]$': 'tuple', 
+                    '^Dict\[\]$': 'dict', '^Dict\[Any, *Any\]$': 'dict', '^List\[Any\]$': 'list',
+                    '^Tuple\[Any\]$': 'tuple', '^Tuple\[Any,+ *.*\]$': 'tuple', '^Set\[Any\]$': 'set'}
+
+    def resolve_alias(t: str):
+        for t_alias in type_aliases:
             if re.search(re.compile(t_alias), t):
-                return re.sub(re.compile(t_alias), alias_dict[t_alias], t)
+                return re.sub(re.compile(t_alias), type_aliases[t_alias], t)
         return None
 
     def resolve_type_alias_params(types_list):
-        type_alias_params = {'^{}$': 'dict', '\\bText\\b': 'str', '^\[\]$': 'list'}
         params_types = []
         for t in literal_eval(types_list):
-            resolved_alias = resolve_alias(type_alias_params, t)
+            resolved_alias = resolve_alias(t)
             if resolved_alias:
                 params_types.append(resolved_alias)
             else:
@@ -53,19 +76,24 @@ def resolve_type_aliasing(df_all: pd.DataFrame) -> pd.DataFrame:
         return str(params_types)
 
     def resolve_type_alias_ret(ret_type):
-        type_alias_ret = {'^{}$': 'dict', '\\bText\\b': 'str', '^\[{}\]$': 'List[dict]',
-                          '^\[\]$': 'list'}
         if ret_type:
-            resolved_alias = resolve_alias(type_alias_ret, str(ret_type))
+            resolved_alias = resolve_alias(str(ret_type))
             if resolved_alias:
                 return resolved_alias
         
         return ret_type
 
+    def resolve_type_alias_var(var_type):
+        resolved_alias = resolve_alias(var_type)
+        if resolved_alias:
+            return resolved_alias
+        return var_type
+
     df_all['return_type'] = df_all['return_type'].apply(resolve_type_alias_ret)
     df_all['arg_types'] = df_all['arg_types'].apply(resolve_type_alias_params)
+    df_vars['var_type'] = df_vars['var_type'].apply(resolve_type_alias_var)
 
-    return df_all
+    return df_all, df_vars
 
 def filter_functions(df: pd.DataFrame, funcs=['str', 'unicode', 'repr', 'len', 'doc', 'sizeof']) -> pd.DataFrame:
     """
@@ -81,6 +109,19 @@ def filter_functions(df: pd.DataFrame, funcs=['str', 'unicode', 'repr', 'len', '
     logger.info(f"Filtered out {df_len - len(df):,} functions.")
 
     return df
+
+def filter_variables(df_vars: pd.DataFrame, types=['Any', 'None', 'object']):
+    """
+    Filters out variables with specified types such as Any or None
+    """
+
+    df_var_len = len(df_vars)
+    logger.info(f"Variables before dropping on {','.join(types)}: {len(df_vars):,}")
+    df_vars = df_vars[~df_vars['var_type'].isin(types)]
+    logger.info(f"Variables after dropping on {','.join(types)}: {len(df_vars):,}")
+    logger.info(f"Filtered out {df_var_len - len(df_vars):,} variables.")
+
+    return df_vars
 
 def gen_argument_df(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -138,13 +179,15 @@ def format_df(df: pd.DataFrame) -> pd.DataFrame:
 
     return df
 
-def encode_all_types(df_ret: pd.DataFrame, df_params: pd.DataFrame,
+def encode_all_types(df_ret: pd.DataFrame, df_params: pd.DataFrame, df_vars: pd.DataFrame,
                      output_dir: str):
-    all_types = np.concatenate((df_ret['return_type'].values, df_params['arg_type'].values), axis=0)
+    all_types = np.concatenate((df_ret['return_type'].values, df_params['arg_type'].values,
+                                df_vars['var_type'].values), axis=0)
     le_all = LabelEncoder()
     le_all.fit(all_types)
     df_ret['return_type_enc_all'] = le_all.transform(df_ret['return_type'].values)
     df_params['arg_type_enc_all'] = le_all.transform(df_params['arg_type'].values)
+    df_vars['var_type_enc_all'] = le_all.transform(df_vars['var_type'].values)
 
     unq_types, count_unq_types = np.unique(all_types, return_counts=True)
     pd.DataFrame(
@@ -181,7 +224,8 @@ def gen_most_frequent_avl_types(avl_types_dir, output_dir, top_n: int = 1024) ->
 
     return df
 
-def encode_aval_types(df_param: pd.DataFrame, df_ret: pd.DataFrame, df_aval_types: pd.DataFrame):
+def encode_aval_types(df_param: pd.DataFrame, df_ret: pd.DataFrame, df_var: pd.DataFrame,
+                      df_aval_types: pd.DataFrame):
     """
     It encodes the type of parameters and return according to visible type hints
     """
@@ -197,6 +241,7 @@ def encode_aval_types(df_param: pd.DataFrame, df_ret: pd.DataFrame, df_aval_type
     # If the arg type doesn't exist in top_n available types, we insert n + 1 into the vector as it represents the other type.
     df_param['param_aval_enc'] = df_param['arg_type'].apply(trans_aval_type)
     df_ret['ret_aval_enc'] = df_ret['return_type'].apply(trans_aval_type)
+    df_var['var_aval_enc'] = df_var['var_type'].apply(trans_aval_type)
 
     return df_param, df_ret
 
@@ -205,9 +250,15 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
     Applies preprocessing steps to the extracted functions
     """
 
-    logger.info("Merging JSON projects and loading functions' Dataframe")
-    create_dataframe_fns(output_dir, merge_jsons_to_dict(list_files(os.path.join(output_dir, 'processed_projects'), ".json"), limit))
+    logger.info("Merging JSON projects")
+    merged_jsons = merge_jsons_to_dict(list_files(os.path.join(output_dir, 'processed_projects'), ".json"), limit)
+    logger.info("Creating functions' Dataframe")
+    create_dataframe_fns(output_dir, merged_jsons)
+    logger.info("Creating variables' Dataframe")
+    create_dataframe_vars(output_dir, merged_jsons)
+    logger.info("Loading vars & fns Dataframe")
     processed_proj_fns = pd.read_csv(os.path.join(output_dir, "all_fns.csv"), low_memory=False)
+    processed_proj_vars = pd.read_csv(os.path.join(output_dir, "all_vars.csv"), low_memory=False)
 
     # Split the processed files into train, validation and test sets
     if all(processed_proj_fns['set'].isin(['train', 'valid', 'test'])):
@@ -215,6 +266,11 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
         train_files = processed_proj_fns['file'][processed_proj_fns['set'] == 'train']
         valid_files = processed_proj_fns['file'][processed_proj_fns['set'] == 'valid']
         test_files = processed_proj_fns['file'][processed_proj_fns['set'] == 'test']
+
+        train_files_vars = processed_proj_vars['file'][processed_proj_vars['set'] == 'train']
+        valid_files_vars = processed_proj_vars['file'][processed_proj_vars['set'] == 'valid']
+        test_files_vars = processed_proj_vars['file'][processed_proj_vars['set'] == 'test']
+
     else:
         logger.info("Splitting sets randomly")
         train_files, test_files = train_test_split(pd.DataFrame(processed_proj_fns['file'].unique(), columns=['file']),
@@ -229,21 +285,35 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
     df_test = processed_proj_fns[processed_proj_fns['file'].isin(test_files.to_numpy().flatten())]
     logger.info(f"No. of functions in test set: {df_test.shape[0]:,}")
 
+    df_var_train = processed_proj_vars[processed_proj_vars['file'].isin(train_files_vars.to_numpy().flatten())]
+    logger.info(f"No. of variables in train set: {df_var_train.shape[0]:,}")
+    df_var_valid = processed_proj_vars[processed_proj_vars['file'].isin(valid_files_vars.to_numpy().flatten())]
+    logger.info(f"No. of variables in validation set: {df_var_valid.shape[0]:,}")
+    df_var_test = processed_proj_vars[processed_proj_vars['file'].isin(test_files_vars.to_numpy().flatten())]
+    logger.info(f"No. of variables in test set: {df_var_test.shape[0]:,}")
+
     assert list(set(df_train['file'].tolist()).intersection(set(df_test['file'].tolist()))) == []
     assert list(set(df_train['file'].tolist()).intersection(set(df_valid['file'].tolist()))) == []
     assert list(set(df_test['file'].tolist()).intersection(set(df_valid['file'].tolist()))) == []
 
-    # Makes type annotations consistent by removing `typing.`, `t.`, and `builtins` from a type.
-    processed_proj_fns = make_types_consistent(processed_proj_fns)
+    # Exclude variables without a type
+    processed_proj_vars = processed_proj_vars[processed_proj_vars['var_type'].notnull()]
 
-    assert any([bool(re.match(r'.*typing\..+|.*t\..+|.*builtins\..+', str(t))) for t in processed_proj_fns['return_type']]) == False
-    assert any([bool(re.match(r'.*typing\..+|.*t\..+|.*builtins\..+', t)) for t in processed_proj_fns['arg_types']]) == False
+    # Makes type annotations consistent by removing `typing.`, `t.`, and `builtins` from a type.
+    processed_proj_fns, processed_proj_vars = make_types_consistent(processed_proj_fns, processed_proj_vars)
+
+    assert any([bool(re.match(sub_regex, str(t))) for t in processed_proj_fns['return_type']]) == False
+    assert any([bool(re.match(sub_regex, t)) for t in processed_proj_fns['arg_types']]) == False
+    assert any([bool(re.match(sub_regex, t)) for t in processed_proj_vars['var_type']]) == False
 
     # Resolves type aliasing and mappings. e.g. `[]` -> `list`
-    processed_proj_fns = resolve_type_aliasing(processed_proj_fns)
+    processed_proj_fns, processed_proj_vars = resolve_type_aliasing(processed_proj_fns, processed_proj_vars)
 
     assert any([bool(re.match(r'^{}$|\bText\b|^\[{}\]$|^\[\]$', str(t))) for t in processed_proj_fns['return_type']]) == False
     assert any([bool(re.match(r'^{}$|\bText\b|^\[\]$', t)) for type_list in processed_proj_fns['arg_types'] for t in literal_eval(type_list)]) == False
+
+    # Filters variables with type Any or None
+    processed_proj_vars = filter_variables(processed_proj_vars)
 
     # Filters trivial functions such as `__str__` and `__len__` 
     processed_proj_fns = filter_functions(processed_proj_fns)
@@ -256,7 +326,8 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
 
     processed_proj_fns = format_df(processed_proj_fns)
 
-    processed_proj_fns, processed_proj_fns_params, le_all = encode_all_types(processed_proj_fns, processed_proj_fns_params, output_dir)
+    processed_proj_fns, processed_proj_fns_params, le_all = encode_all_types(processed_proj_fns, processed_proj_fns_params,
+                                                                             processed_proj_vars, output_dir)
 
     # Exclude self from arg names and return expressions
     processed_proj_fns['arg_names_str'] = processed_proj_fns['arg_names'].apply(lambda l: " ".join([v for v in l if v != 'self']))
@@ -268,7 +339,8 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
 
     # Find most frequent visible type hints
     df_types = gen_most_frequent_avl_types(os.path.join(output_dir, "extracted_visible_types"), output_dir)
-    processed_proj_fns_params, processed_proj_fns = encode_aval_types(processed_proj_fns_params, processed_proj_fns, df_types)
+    processed_proj_fns_params, processed_proj_fns = encode_aval_types(processed_proj_fns_params, processed_proj_fns,
+                                                                      processed_proj_vars, df_types)
 
     # Split parameters and returns type dataset by file into a train and test sets
     df_params_train = processed_proj_fns_params[processed_proj_fns_params['file'].isin(train_files.to_numpy().flatten())]
@@ -279,6 +351,11 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
     df_ret_valid = processed_proj_fns[processed_proj_fns['file'].isin(valid_files.to_numpy().flatten())]
     df_ret_test = processed_proj_fns[processed_proj_fns['file'].isin(test_files.to_numpy().flatten())]
 
+    df_var_train = processed_proj_vars[processed_proj_vars['file'].isin(train_files_vars.to_numpy().flatten())]
+    df_var_valid = processed_proj_vars[processed_proj_vars['file'].isin(valid_files_vars.to_numpy().flatten())]
+    df_var_test = processed_proj_vars[processed_proj_vars['file'].isin(test_files_vars.to_numpy().flatten())]
+
+
     assert list(set(df_params_train['file'].tolist()).intersection(set(df_params_test['file'].tolist()))) == []
     assert list(set(df_params_train['file'].tolist()).intersection(set(df_params_valid['file'].tolist()))) == []
     assert list(set(df_params_test['file'].tolist()).intersection(set(df_params_valid['file'].tolist()))) == []
@@ -286,6 +363,10 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
     assert list(set(df_ret_train['file'].tolist()).intersection(set(df_ret_test['file'].tolist()))) == []
     assert list(set(df_ret_train['file'].tolist()).intersection(set(df_ret_valid['file'].tolist()))) == []
     assert list(set(df_ret_test['file'].tolist()).intersection(set(df_ret_valid['file'].tolist()))) == []
+
+    assert list(set(df_var_train['file'].tolist()).intersection(set(df_var_test['file'].tolist()))) == []
+    assert list(set(df_var_train['file'].tolist()).intersection(set(df_var_valid['file'].tolist()))) == []
+    assert list(set(df_var_test['file'].tolist()).intersection(set(df_var_valid['file'].tolist()))) == []
 
     # Store the dataframes and the label encoders
     logger.info("Saving preprocessed functions on the disk...")
@@ -295,6 +376,11 @@ def preprocess_ext_fns(output_dir: str, limit: int = None):
     df_params_train.to_csv(os.path.join(output_dir, "_ml_param_train.csv"), index=False)
     df_params_valid.to_csv(os.path.join(output_dir, "_ml_param_valid.csv"), index=False)
     df_params_test.to_csv(os.path.join(output_dir, "_ml_param_test.csv"), index=False)
+
     df_ret_train.to_csv(os.path.join(output_dir, "_ml_ret_train.csv"), index=False)
     df_ret_valid.to_csv(os.path.join(output_dir, "_ml_ret_valid.csv"), index=False)
     df_ret_test.to_csv(os.path.join(output_dir, "_ml_ret_test.csv"), index=False)
+
+    df_var_train.to_csv(os.path.join(output_dir, "_ml_var_train.csv"), index=False)
+    df_var_valid.to_csv(os.path.join(output_dir, "_ml_var_valid.csv"), index=False)
+    df_var_test.to_csv(os.path.join(output_dir, "_ml_var_test.csv"), index=False)

--- a/type4py/vectorize.py
+++ b/type4py/vectorize.py
@@ -1,7 +1,7 @@
 from gensim.models import Word2Vec
 from time import time
 from tqdm import tqdm
-from type4py import logger
+from type4py import logger, AVAILABLE_TYPES_NUMBER
 from type4py.utils import mk_dir_not_exist
 import os
 import multiprocessing
@@ -12,7 +12,6 @@ logger.name = __name__
 tqdm.pandas()
 
 W2V_VEC_LENGTH = 100
-AVAILABLE_TYPES_NUMBER = 1024
 
 class TokenIterator:
     def __init__(self, param_df: pd.DataFrame, return_df: pd.DataFrame,

--- a/type4py/vectorize.py
+++ b/type4py/vectorize.py
@@ -15,9 +15,11 @@ W2V_VEC_LENGTH = 100
 AVAILABLE_TYPES_NUMBER = 1024
 
 class TokenIterator:
-    def __init__(self, param_df: pd.DataFrame, return_df: pd.DataFrame) -> None:
+    def __init__(self, param_df: pd.DataFrame, return_df: pd.DataFrame,
+                 var_df: pd.DataFrame) -> None:
         self.param_df = param_df
         self.return_df = return_df
+        self.var_df = var_df
 
     def __iter__(self):
         for return_expr_sentences in self.return_df['return_expr_str'][self.return_df['return_expr_str'] != '']:
@@ -32,13 +34,21 @@ class TokenIterator:
         for arg_names_sentences in self.return_df['arg_names_str'][self.return_df['arg_names_str'] != '']:
             yield arg_names_sentences.split()
 
+        for var_names_sentences in self.var_df['var_name'][self.var_df['var_name'].notnull()]:
+            yield var_names_sentences.split()
+
+        for var_occur_sentences in self.var_df['var_occur'][self.var_df['var_occur'] != '']:
+            yield var_occur_sentences.split()
+
 class W2VEmbedding:
     """
     Word2Vec embeddings for code tokens and identifiers
     """
-    def __init__(self, param_df: pd.DataFrame, return_df: pd.DataFrame, w2v_model_tk_path) -> None:
+    def __init__(self, param_df: pd.DataFrame, return_df: pd.DataFrame,
+                 var_df: pd.DataFrame, w2v_model_tk_path) -> None:
         self.param_df = param_df
         self.return_df = return_df
+        self.var_df = var_df
         self.w2v_model_tk_path = w2v_model_tk_path
 
     def train_model(self, corpus_iterator: TokenIterator, model_path_name: str) -> None:
@@ -48,28 +58,23 @@ class W2VEmbedding:
         :param model_path_name: path name of the output file
         """
 
-        cores = multiprocessing.cpu_count()
-
         w2v_model = Word2Vec(min_count=5,
                              window=5,
                              size=W2V_VEC_LENGTH,
-                             workers=cores-1)
+                             workers=multiprocessing.cpu_count())
 
         t = time()
-
         w2v_model.build_vocab(sentences=corpus_iterator)
-
         logger.info('Built W2V vocab in {} mins'.format(round((time() - t) / 60, 2)))
+        logger.info(f"W2V model's vocab size: {len(w2v_model.wv.vocab):,}")
 
         t = time()
-
         w2v_model.train(sentences=corpus_iterator,
                         total_examples=w2v_model.corpus_count,
                         epochs=20,
                         report_delay=1)
 
         logger.info('Built W2V model in {} mins'.format(round((time() - t) / 60, 2)))
-
         w2v_model.save(model_path_name)
 
     def train_token_model(self):
@@ -77,7 +82,7 @@ class W2VEmbedding:
         Trains a W2V model for tokens.
         """
 
-        self.train_model(TokenIterator(self.param_df, self.return_df), self.w2v_model_tk_path)
+        self.train_model(TokenIterator(self.param_df, self.return_df, self.var_df), self.w2v_model_tk_path)
 
 def vectorize_sequence(sequence: str, feature_length: int, w2v_model: Word2Vec) -> np.ndarray:
     """
@@ -100,12 +105,13 @@ class IdentifierSequence:
     """
     Vector representation of identifiers
     """
-    def __init__(self, identifiers_embd, arg_name, args_name, func_name):
+    def __init__(self, identifiers_embd, arg_name, args_name, func_name, var_name):
 
         self.identifiers_embd = identifiers_embd
         self.arg_name = arg_name
         self.args_name = args_name
         self.func_name = func_name
+        self.var_name = var_name
 
     def seq_length_param(self):
 
@@ -125,7 +131,12 @@ class IdentifierSequence:
             "padding": 10
         }
 
-    def generate_datapoint(self, seq_length):
+    def seq_length_var(self):
+        return {
+            'var_name': 10,
+        } # TODO: padding needed for combining with ret & param
+
+    def __gen_datapoint(self, seq_length):
         datapoint = np.zeros((sum(seq_length.values()), W2V_VEC_LENGTH))
         separator = np.ones(W2V_VEC_LENGTH)
 
@@ -148,31 +159,40 @@ class IdentifierSequence:
 
         return datapoint
 
-    def param_datapoint(self):
+    # def param_datapoint(self):
+    #     return self.__gen_datapoint(self.seq_length_param())
 
-        return self.generate_datapoint(self.seq_length_param())
+    # def return_datapoint(self):
+    #     return self.__gen_datapoint(self.seq_length_return())
 
-    def return_datapoint(self):
+    # def var_datapoint(self):
+    #     return self.__gen_datapoint(self.seq_length_var())
 
-        return self.generate_datapoint(self.seq_length_return())
-
+    def generate_datapoint(self):
+        if self.arg_name is not None and self.args_name is not None and self.func_name is None:
+            return self.__gen_datapoint(self.seq_length_param())
+        elif self.args_name is not None and self.func_name is not None:
+            return self.__gen_datapoint(self.seq_length_return())
+        elif self.var_name is not None:
+            return self.__gen_datapoint(self.seq_length_var())
 
 class TokenSequence:
     """
     Vector representation of code tokens
     """
-    def __init__(self, token_model, len_tk_seq, num_tokens_seq, args_usage, return_expr):
+    def __init__(self, token_model, len_tk_seq, num_tokens_seq, args_usage,
+                 return_expr, var_usage):
         self.token_model = token_model
         self.len_tk_seq = len_tk_seq
         self.num_tokens_seq = num_tokens_seq
         self.args_usage = args_usage
         self.return_expr = return_expr
+        self.var_usage = var_usage
 
     def param_datapoint(self):
         datapoint = np.zeros((self.num_tokens_seq*self.len_tk_seq, W2V_VEC_LENGTH))
         for i, w in enumerate(vectorize_sequence(self.args_usage, self.num_tokens_seq*self.len_tk_seq, self.token_model)):
             datapoint[i] = w
-
         return datapoint
 
     def return_datapoint(self):
@@ -183,8 +203,21 @@ class TokenSequence:
             for w in vectorize_sequence(self.return_expr, self.len_tk_seq, self.token_model):
                 datapoint[p] = w
                 p += 1
-
         return datapoint
+
+    def var_datapoint(self):
+        datapoint = np.zeros((self.num_tokens_seq*self.len_tk_seq, W2V_VEC_LENGTH))
+        for i, w in enumerate(vectorize_sequence(self.var_usage, self.num_tokens_seq*self.len_tk_seq, self.token_model)):
+            datapoint[i] = w
+        return datapoint
+
+    def generate_datapoint(self):
+        if self.args_usage is not None:
+            return self.param_datapoint()
+        elif self.return_expr is not None:
+            return self.return_datapoint()
+        elif self.var_usage is not None:
+            return self.var_datapoint()
 
 def process_datapoints(f_name, output_path, embedding_type, type, trans_func, cached_file: bool=False):
 
@@ -192,7 +225,7 @@ def process_datapoints(f_name, output_path, embedding_type, type, trans_func, ca
         df = pd.read_csv(f_name, na_filter=False)
         datapoints = df.apply(trans_func, axis=1)
 
-        datapoints_X = np.stack(datapoints.progress_apply(lambda x: x.return_datapoint() if 'ret' in type else x.param_datapoint()),
+        datapoints_X = np.stack(datapoints.progress_apply(lambda x: x.generate_datapoint()),
                                 axis=0)
         np.save(os.path.join(output_path, embedding_type + type + '_datapoints_x'), datapoints_X)
 
@@ -206,43 +239,52 @@ def type_vector(size, index):
     v[index] = 1
     return v
 
-def gen_aval_types_datapoints(df_params, df_ret, set_type, output_path, cached_file: bool=False):
+def gen_aval_types_datapoints(df_params, df_ret, df_var, set_type, output_path, cached_file: bool=False):
     """
     It generates data points for available types.
     """
 
     if not (os.path.exists(os.path.join(output_path, f'params_{set_type}_aval_types_dp.npy')) and os.path.exists(os.path.join(output_path,
-            f'ret_{set_type}_aval_types_dp.npy'))) or not cached_file:
+            f'ret_{set_type}_aval_types_dp.npy'))) and os.path.exists(os.path.join(output_path, f'var_{set_type}_aval_types_dp.npy')) \
+                 or not cached_file:
 
         df_params = pd.read_csv(df_params)
         df_ret = pd.read_csv(df_ret)
+        df_var = pd.read_csv(df_var)
 
         aval_types_params = np.stack(df_params.progress_apply(lambda row: type_vector(AVAILABLE_TYPES_NUMBER, row.param_aval_enc),
                                                     axis=1), axis=0)
         aval_types_ret = np.stack(df_ret.progress_apply(lambda row: type_vector(AVAILABLE_TYPES_NUMBER, row.ret_aval_enc),
                                             axis=1), axis=0)
+        aval_types_var = np.stack(df_var.progress_apply(lambda row: type_vector(AVAILABLE_TYPES_NUMBER, row.var_aval_enc),
+                                            axis=1), axis=0)
 
         np.save(os.path.join(output_path, f'params_{set_type}_aval_types_dp'), aval_types_params)
         np.save(os.path.join(output_path, f'ret_{set_type}_aval_types_dp'), aval_types_ret)
+        np.save(os.path.join(output_path, f'var_{set_type}_aval_types_dp'), aval_types_var)
 
-        return aval_types_params, aval_types_ret
+        return aval_types_params, aval_types_ret, aval_types_var
     else:
         logger.warn(f'file params_{set_type}_aval_types_dp.npy exists!')
         logger.warn(f'file ret_{set_type}_aval_types_dp.npy exists!')
-        return None, None
+        logger.warn(f'file var_{set_type}_aval_types_dp.npy exists!')
+        return None, None, None
 
-def gen_labels_vector(params_df: pd.DataFrame, returns_df: pd.DataFrame, set_type: str, output_path: str):
+def gen_labels_vector(params_df: pd.DataFrame, returns_df: pd.DataFrame, var_df: pd.DataFrame,
+                      set_type: str, output_path: str):
     """
     It generates a flattened labels vector
     """
 
     params_df = pd.read_csv(params_df)
     returns_df = pd.read_csv(returns_df)
+    var_df = pd.read_csv(var_df)
 
     np.save(os.path.join(output_path, f'params_{set_type}_dps_y_all'), params_df['arg_type_enc_all'].values)
     np.save(os.path.join(output_path, f'ret_{set_type}_dps_y_all'), returns_df['return_type_enc_all'].values)
+    np.save(os.path.join(output_path, f'var_{set_type}_dps_y_all'), var_df['var_type_enc_all'].values)
 
-    return params_df['arg_type_enc_all'].values, returns_df['return_type_enc_all'].values
+    return params_df['arg_type_enc_all'].values, returns_df['return_type_enc_all'].values, var_df['var_type_enc_all'].values
 
 def vectorize_args_ret(output_path: str):
     """
@@ -251,15 +293,17 @@ def vectorize_args_ret(output_path: str):
 
     param_df = pd.read_csv(os.path.join(output_path, "_ml_param_train.csv"), na_filter=False)
     return_df = pd.read_csv(os.path.join(output_path, "_ml_ret_train.csv"), na_filter=False)
+    var_df = pd.read_csv(os.path.join(output_path, "_ml_var_train.csv"), na_filter=False)
 
     logger.info(f"No. of parameters types in train set: {param_df.shape[0]:,}")
     logger.info(f"No. of returns types in train set: {return_df.shape[0]:,}")
+    logger.info(f"No. of variables types in train set: {var_df.shape[0]:,}")
 
-    embedder = W2VEmbedding(param_df, return_df, os.path.join(output_path, 'w2v_token_model.bin'))
+    embedder = W2VEmbedding(param_df, return_df, var_df,
+                            os.path.join(output_path, 'w2v_token_model.bin'))
     embedder.train_token_model()
 
     w2v_token_model = Word2Vec.load(os.path.join(output_path, 'w2v_token_model.bin'))
-    logger.info(f"W2V model's vocab size : {len(w2v_token_model.wv.vocab):,}")
 
     # Create dirs for vectors
     mk_dir_not_exist(os.path.join(output_path, "vectors"))
@@ -270,8 +314,10 @@ def vectorize_args_ret(output_path: str):
     tks_seq_len = (7, 3)
     vts_seq_len = (15, 5)
     # Vectorize functions' arguments
-    id_trans_func_param = lambda row: IdentifierSequence(w2v_token_model, row.arg_name, row.other_args, row.func_name)
-    token_trans_func_param = lambda row: TokenSequence(w2v_token_model, tks_seq_len[0], tks_seq_len[1], row.arg_occur, None)
+    id_trans_func_param = lambda row: IdentifierSequence(w2v_token_model, row.arg_name, row.other_args,
+                                                         row.func_name, None)
+    token_trans_func_param = lambda row: TokenSequence(w2v_token_model, tks_seq_len[0], tks_seq_len[1],
+                                                       row.arg_occur, None, None)
 
     # Identifiers
     logger.info("[arg][identifiers] Generating vectors")
@@ -298,8 +344,9 @@ def vectorize_args_ret(output_path: str):
                        'tokens_', 'param_test', token_trans_func_param)
 
     # Vectorize functions' return types
-    id_trans_func_ret = lambda row: IdentifierSequence(w2v_token_model, None, row.arg_names_str, row.name)
-    token_trans_func_ret = lambda row: TokenSequence(w2v_token_model, tks_seq_len[0], tks_seq_len[1], None, row.return_expr_str)
+    id_trans_func_ret = lambda row: IdentifierSequence(w2v_token_model, None, row.arg_names_str, row.name, None)
+    token_trans_func_ret = lambda row: TokenSequence(w2v_token_model, tks_seq_len[0], tks_seq_len[1], None,
+                                                     row.return_expr_str, None)
 
     # Identifiers
     logger.info("[ret][identifiers] Generating vectors")
@@ -325,28 +372,63 @@ def vectorize_args_ret(output_path: str):
                        os.path.join(output_path, "vectors", "test"),
                        'tokens_', 'ret_test', token_trans_func_ret)
 
+    # Vectorize variables types
+    id_trans_func_var = lambda row: IdentifierSequence(w2v_token_model, None, None, None, row.var_name)
+    token_trans_func_var = lambda row: TokenSequence(w2v_token_model, tks_seq_len[0], tks_seq_len[1], None,
+                                                     None, row.var_occur)
+
+    # Identifiers
+    logger.info("[var][identifiers] Generating vectors")
+    process_datapoints(os.path.join(output_path, "_ml_var_train.csv"),
+                       os.path.join(output_path, "vectors", "train"),
+                       'identifiers_', 'var_train', id_trans_func_var)
+    process_datapoints(os.path.join(output_path, "_ml_var_valid.csv"),
+                       os.path.join(output_path, "vectors", "valid"),
+                       'identifiers_', 'var_valid', id_trans_func_var)
+    process_datapoints(os.path.join(output_path, "_ml_var_test.csv"),
+                       os.path.join(output_path, "vectors", "test"),
+                       'identifiers_', 'var_test', id_trans_func_var)
+
+    # Tokens
+    logger.info("[var][code tokens] Generating vectors")
+    process_datapoints(os.path.join(output_path, "_ml_var_train.csv"),
+                       os.path.join(output_path, "vectors", "train"),
+                       'tokens_', 'var_train', token_trans_func_var)
+    process_datapoints(os.path.join(output_path, "_ml_var_valid.csv"),
+                       os.path.join(output_path, "vectors", "valid"),
+                       'tokens_', 'var_valid', token_trans_func_var)
+    process_datapoints(os.path.join(output_path, "_ml_var_test.csv"),
+                       os.path.join(output_path, "vectors", "test"),
+                       'tokens_', 'var_test', token_trans_func_var)
+    
     # Generate data points for visible type hints
     logger.info("[visible type hints] Generating vectors")
     gen_aval_types_datapoints(os.path.join(output_path, "_ml_param_train.csv"),
                               os.path.join(output_path, "_ml_ret_train.csv"),
+                              os.path.join(output_path, "_ml_var_train.csv"),
                               'train', os.path.join(output_path, "vectors", "train"))
     gen_aval_types_datapoints(os.path.join(output_path, "_ml_param_valid.csv"),
                               os.path.join(output_path, "_ml_ret_valid.csv"),
+                              os.path.join(output_path, "_ml_var_valid.csv"),
                               'valid', os.path.join(output_path, "vectors", "valid"))
     gen_aval_types_datapoints(os.path.join(output_path, "_ml_param_test.csv"),
                               os.path.join(output_path, "_ml_ret_test.csv"),
+                              os.path.join(output_path, "_ml_var_test.csv"),
                               'test', os.path.join(output_path, "vectors", "test"))
 
     # a flattened vector for labels
     logger.info("[true labels] Generating vectors")
     gen_labels_vector(os.path.join(output_path, "_ml_param_train.csv"),
                       os.path.join(output_path, "_ml_ret_train.csv"),
+                      os.path.join(output_path, "_ml_var_train.csv"),
                       'train', os.path.join(output_path, "vectors", "train"))
     gen_labels_vector(os.path.join(output_path, "_ml_param_valid.csv"),
                       os.path.join(output_path, "_ml_ret_valid.csv"),
+                      os.path.join(output_path, "_ml_var_valid.csv"),
                       'valid', os.path.join(output_path, "vectors", "valid"))
     gen_labels_vector(os.path.join(output_path, "_ml_param_test.csv"),
                       os.path.join(output_path, "_ml_ret_test.csv"),
+                      os.path.join(output_path, "_ml_var_test.csv"),
                       'test', os.path.join(output_path, "vectors", "test"))
     
 


### PR DESCRIPTION
- Extend `preprocess` and `vectorize` modules for variables prediction
- Extend `data_loaders` module for loading variables' tensors
- Separating ubiquitous and common types when evaluating
- Considering Visible Type Hints in `preprocess` module
- Evaluating different tasks in the `eval` module i.e., parameters, return, and variable
- Adding the Type4Py model with different configurations
- Improving the performance of data loaders
- In `eval`, consider MRR instead of weighted metrics
- `predict` now creates a JSON file for predictions
- Improve the memory consumption of `predict`
- Improvements to `predict`: better type aliasing & reducing the depth of parametric types
- Determining no. of batches when predicting different from the training phase